### PR TITLE
Fix nfstest_posix stat_test() and open_test()

### DIFF
--- a/test/nfstest_posix
+++ b/test/nfstest_posix
@@ -831,14 +831,16 @@ class PosixTest(TestUtil):
         testdir = self.absdir
 
         self.test_info("Symbolic link to a file")
-        srcfile = testfile
+        cwd=os.getcwd()
+        srcfile = cwd+'/'+testfile
         self.get_filename()
         self.dprint('DBG3', "Creating symbolic link to file [%s -> %s]" % (self.absfile, srcfile))
         os.symlink(srcfile, self.absfile)
         self._stat_obj(0754, stat_mode=stat_mode, type='symbolic link', srcfile=srcfile)
 
         self.test_info("Symbolic link to a directory")
-        srcfile = testdir
+        cwd=os.getcwd()
+        srcfile = cwd+'/'+testdir
         self.get_filename()
         self.dprint('DBG3', "Creating symbolic link to directory [%s -> %s]" % (self.absfile, srcfile))
         os.symlink(srcfile, self.absfile)

--- a/test/nfstest_posix
+++ b/test/nfstest_posix
@@ -1065,7 +1065,7 @@ class PosixTest(TestUtil):
                 os.chmod(self.absfile, 0777)
                 if ftype == SYMLINK:
                     # Create symbolic link
-                    srcfile = self.absfile
+                    srcfile = os.getcwd()+'/'+self.absfile
                     self.get_filename()
                     self.dprint('DBG3', "Creating symbolic link file [%s -> %s]" % (self.absfile, srcfile))
                     os.symlink(srcfile, self.absfile)


### PR DESCRIPTION
Failed to create a new symlink when using os.symlink(), the srcfile path is should be a absolute path